### PR TITLE
Do not recommend normal xxhdpi assets.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,10 +138,7 @@
 				<td>480</td>
 				<td>3.0</td>
 				<td>144 x 144<br />126 x 126</td>
-				<td>96 x 96<br />72 x 72</td>
-				<td>72 x 72<br />66 x 66</td>
-				<td>48 x 75<br />48 x 48</td>
-				<td>75 x 75<br />63 x 63</td>
+				<td colspan="4" style="text-align: center;">Not needed</td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
For now, the 'xxhdpi' qualifier is only used explicitly for launcher icons on large, high density displays. Creating all your assets as xxhdpi is not recommended.

![Screen Shot 2013-04-19 at 1 53 20 PM](https://f.cloud.github.com/assets/66577/403973/307ebe04-a933-11e2-9768-995bb95db720.png)
